### PR TITLE
キャラのすり抜けを防止(ごり押し)してみました

### DIFF
--- a/Assets/Script/CameraMove.cs
+++ b/Assets/Script/CameraMove.cs
@@ -14,7 +14,7 @@ public class CameraMove : MonoBehaviour
     bool cursorLock = true;
 
     //•Ï”‚ÌéŒ¾(Šp“x‚Ì§ŒÀ—p)
-    float minX = -90f, maxX = 90f;
+    float minX = -70f, maxX = 45f;
 
     // Start is called before the first frame update
     void Start()
@@ -52,7 +52,7 @@ public class CameraMove : MonoBehaviour
 
         //transform.position += new Vector3(x,0,z);
 
-        transform.position += cam.transform.forward * z + cam.transform.right * x;
+        transform.position += cam.transform.forward * z / 2 + cam.transform.right * x / 2;
     }
 
 

--- a/Assets/Script/PlayerJumpTest.cs
+++ b/Assets/Script/PlayerJumpTest.cs
@@ -12,7 +12,7 @@ public class PlayerJumpTest : MonoBehaviour
     {
         rb = GetComponent<Rigidbody>();
         UpForce = 500;
-        Distance = 1.0f;
+        Distance = 3.0f;
     }
 
     // Update is called once per frame


### PR DESCRIPTION
速度を落とし、角度を制限することですり抜けを防止しました。気に入らなかったら消してくれてかまいません。どうせならガチャのすり抜けも防止したい。